### PR TITLE
Restrict supported node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "url": "https://github.com/andersonshatch/soma-ctrl"
   },
   "homepage": "https://github.com/andersonshatch/soma-ctrl#readme",
+  "engines": {
+    "node": ">=0.8 <10.0"
+  },
   "dependencies": {
     "debug": "^3.1.0",
     "express": "^4.16.3",


### PR DESCRIPTION
Currently issues with noble and node 10.x