### PR TITLE
Allow specifying non-RISE prefixed IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ You may optionally:
 - Alter the device scanning timeout, e.g. scan for 60 seconds: `somactrl -t 60`
 - Specify the number of devices you expect to connect to, e.g. 4 devices expected: `somactrl -e 4`
 - Manually specify a list of device IDs to connect to, e.g. connect to RISE108 and RISE117: `somactrl RISE108 RISE117`
+- Manually specify a list of MAC addresses to connect to, e.g.: `somactrl f5:11:7b:ee:f3:43`
 
 
 You must then specify options to use either MQTT, HTTP or both

--- a/index.js
+++ b/index.js
@@ -69,8 +69,8 @@ if (argv.p === true) {
     argv.p = readlineSync.question('MQTT Password: ', {hideEchoBack: true, mask: ''});
 }
 
-const idsToConnectTo = argv._.filter(name => name.startsWith('RISE'));
-const idsToIgnore = argv._.filter(name => name.startsWith('_RISE')).map(id => id.substr(1));
+const idsToConnectTo = argv._;
+const idsToIgnore = argv._.filter(name => name.startsWith('_')).map(id => id.substr(1));
 
 const manualIdsWereSpecified = idsToConnectTo.length !== 0;
 if (!manualIdsWereSpecified) {
@@ -134,7 +134,7 @@ let loggedStop = false;
 
 noble.on('discover', peripheral => {
     if (peripheral.advertisement !== undefined && peripheral.advertisement.localName !== undefined &&
-            peripheral.advertisement.localName.startsWith('RISE')) {
+            (peripheral.advertisement.localName.startsWith('RISE') || idsToConnectTo.indexOf(peripheral.advertisement.localName) !== -1)) {
 
         let id = peripheral.advertisement.localName;
 

--- a/index.js
+++ b/index.js
@@ -130,13 +130,25 @@ if (expressPort) {
     new WebBinding(devices, expressPort, debugLog);
 }
 
+function shouldConnect(peripheral) {
+    if (peripheral.advertisement !== undefined && peripheral.advertisement.localName !== undefined) {
+        let localName = peripheral.advertisement.localName;
+        if (localName == 'S' || localName.startsWith('RISE') || idsToConnectTo.indexOf(localName) !== -1) {
+            return true;
+        }
+    }
+
+    if (peripheral.id !== undefined && idsToConnectTo.indexOf(peripheral.id.toLowerCase()) !== -1) {
+        return true;
+    }
+
+    return false;
+}
+
 let loggedStop = false;
 
 noble.on('discover', peripheral => {
-    if ((peripheral.advertisement !== undefined && peripheral.advertisement.localName !== undefined &&
-            (peripheral.advertisement.localName.startsWith('RISE') || idsToConnectTo.indexOf(peripheral.advertisement.localName) !== -1)) ||
-			peripheral.address !== undefined && idsToConnectTo.indexOf(peripheral.address.toLowerCase()) !== -1) {
-
+    if (shouldConnect(peripheral)) {
         let address = peripheral.address !== undefined ? peripheral.address.replace(/:/g, '') : undefined;
         let localName = peripheral.advertisement !== undefined ? peripheral.advertisement.localName : undefined;
         let id;

--- a/index.js
+++ b/index.js
@@ -139,7 +139,12 @@ noble.on('discover', peripheral => {
 
         let address = peripheral.address !== undefined ? peripheral.address.replace(/:/g, '') : undefined;
         let localName = peripheral.advertisement !== undefined ? peripheral.advertisement.localName : undefined;
-        let id = localName || address;
+        let id;
+        if (localName !== undefined && localName.startsWith('RISE')) {
+            id = localName;
+        } else {
+            id = address;
+        }
 
         if (idsToIgnore.indexOf(id) !== -1) {
             debugLog('Found %s but will not connect as it is in the ignored ID list', id);


### PR DESCRIPTION
According to issue #27, newer devices don't have RISE prefixed IDs.
Allow connecting to any MAC address or ID explicitly passed in to the tool no matter what format, and discover devices named `S` + the original `RISE` prefixes as before