### PR TITLE
Fixing version string in previous PR, target @abandonware/noble and bluetooth-hci-socket

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: node_js
 node_js:
-- '7'
 - '8'
 - '9'
+- '10'
+- '12'
 deploy:
   provider: npm
   email: andersonshatch@gmail.com

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Util for controlling SOMA smart shade, either over MQTT or via a HTTP API
 - SOMA smart shade device that has been configured with the SOMA app
 - Bluetooth 4.0 LE hardware
 - OS supported by [noble](https://github.com/noble/noble) (I've only tested on macOS and Raspbian)
-- Node 7.0 to 9.x (noble currently has issues with 10.x and up)
+- Node 8.16.1 or higher (tested on 8.16.1, 9.11.2, 10.15.2 and 12.10.0)
 - (Potentially a Bluetooth stick to itself, if you're using some other Bluetooth software, see [#59](https://github.com/andersonshatch/soma-ctrl/issues/59#issuecomment-497662843))
 
 # Installation

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Util for controlling SOMA smart shade, either over MQTT or via a HTTP API
 - SOMA smart shade device that has been configured with the SOMA app
 - Bluetooth 4.0 LE hardware
 - OS supported by [noble](https://github.com/noble/noble) (I've only tested on macOS and Raspbian)
-- Node 8.16.1 or higher (tested on 8.16.1, 9.11.2, 10.15.2 and 12.10.0)
+- Node 8.16.1 or higher (Tested on Node 12.10.0, 11.15.0, 10.15.2, 9.11.2, 8.16.1)
 - (Potentially a Bluetooth stick to itself, if you're using some other Bluetooth software, see [#59](https://github.com/andersonshatch/soma-ctrl/issues/59#issuecomment-497662843))
 
 # Installation

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const readlineSync = require('readline-sync');
-const noble = require('noble');
+const noble = require('@abandonware/noble');
 const log = require('debug')('soma*');
 const debugLog = require('debug')('soma');
 const SomaShade = require('./src/SomaShade');

--- a/package-lock.json
+++ b/package-lock.json
@@ -139,9 +139,9 @@
       }
     },
     "@abandonware/bluetooth-hci-socket": {
-      "version": "0.5.3-1",
-      "resolved": "https://registry.npmjs.org/@abandonware/bluetooth-hci-socket/-/bluetooth-hci-socket-0.5.3-1.tgz",
-      "integrity": "sha512-NzLRq7mjAmvLDRA0E5hvCRtsuV0tq5fbUFxLxSmakRu9K4VM6u7P+3PvAkcylX3CEq0BY9Wwe3KXiMrQBjbMhg==",
+      "version": "0.5.3-3",
+      "resolved": "https://registry.npmjs.org/@abandonware/bluetooth-hci-socket/-/bluetooth-hci-socket-0.5.3-3.tgz",
+      "integrity": "sha512-SkT5yVoaceiWOK1eWW/QCgAaPph/Y+EkOVBvETmhsD1hhKa83+EmVRMjubO68k54uoIzviqcNhxZI/LuIU2PHA==",
       "optional": true,
       "requires": {
         "debug": "^4.1.0",
@@ -1520,9 +1520,9 @@
       "dev": true
     },
     "@abandonware/noble": {
-      "version": "1.9.2-1",
-      "resolved": "https://registry.npmjs.org/@abandonware/noble/-/noble-1.9.2-1.tgz",
-      "integrity": "sha512-M6NTjC+ZrMo/TuTRw0JNztiBjzMWcDPKx06MT1PEIwf+Lh+qeTCpRzsruWfrxEhssM77+8OaDaGsxYMIB1yAkw==",
+      "version": "1.9.2-5",
+      "resolved": "https://registry.npmjs.org/@abandonware/noble/-/noble-1.9.2-5.tgz",
+      "integrity": "sha512-Y1eyxDoA9kvKeAgd6mQ9c4qDbqQbqlPR56LkbtlAqptGB4HT/8KQweqqyTsj4CtdhbvCAt1G+J+2nE35WU9fBg==",
       "requires": {
         "@abandonware/bluetooth-hci-socket": "^0.5.3-1",
         "bplist-parser": "0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -138,26 +138,16 @@
         "safe-buffer": "^5.1.1"
       }
     },
-    "bluetooth-hci-socket": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/bluetooth-hci-socket/-/bluetooth-hci-socket-0.5.1.tgz",
-      "integrity": "sha1-774hUk/Bz10/rl1RNl1WHUq77Qs=",
+    "@abandonware/bluetooth-hci-socket": {
+      "version": "0.5.3-1",
+      "resolved": "https://registry.npmjs.org/@abandonware/bluetooth-hci-socket/-/bluetooth-hci-socket-0.5.3-1.tgz",
+      "integrity": "sha512-NzLRq7mjAmvLDRA0E5hvCRtsuV0tq5fbUFxLxSmakRu9K4VM6u7P+3PvAkcylX3CEq0BY9Wwe3KXiMrQBjbMhg==",
       "optional": true,
       "requires": {
-        "debug": "^2.2.0",
-        "nan": "^2.0.5",
+        "debug": "^4.1.0",
+        "nan": "^2.10.0",
+        "node-pre-gyp": "^0.12.0",
         "usb": "^1.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "body-parser": {
@@ -1529,30 +1519,15 @@
       "integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA==",
       "dev": true
     },
-    "noble": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/noble/-/noble-1.9.1.tgz",
-      "integrity": "sha1-LM0x6tjsktv/bxmkLkILJYvNzdA=",
+    "@abandonware/noble": {
+      "version": "1.9.2-5",
+      "resolved": "https://registry.npmjs.org/@abandonware/noble/-/noble-1.9.2-5.tgz",
+      "integrity": "sha512-M6NTjC+ZrMo/TuTRw0JNztiBjzMWcDPKx06MT1PEIwf+Lh+qeTCpRzsruWfrxEhssM77+8OaDaGsxYMIB1yAkw==",
       "requires": {
-        "bluetooth-hci-socket": "^0.5.1",
-        "bplist-parser": "0.0.6",
-        "debug": "~2.2.0",
+        "@abandonware/bluetooth-hci-socket": "^0.5.3-1",
+        "bplist-parser": "0.1.1",
+        "debug": "^4.1.0",
         "xpc-connection": "~0.1.4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
-        }
       }
     },
     "node-pre-gyp": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1520,8 +1520,8 @@
       "dev": true
     },
     "@abandonware/noble": {
-      "version": "1.9.2-5",
-      "resolved": "https://registry.npmjs.org/@abandonware/noble/-/noble-1.9.2-5.tgz",
+      "version": "1.9.2-1",
+      "resolved": "https://registry.npmjs.org/@abandonware/noble/-/noble-1.9.2-1.tgz",
       "integrity": "sha512-M6NTjC+ZrMo/TuTRw0JNztiBjzMWcDPKx06MT1PEIwf+Lh+qeTCpRzsruWfrxEhssM77+8OaDaGsxYMIB1yAkw==",
       "requires": {
         "@abandonware/bluetooth-hci-socket": "^0.5.3-1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/andersonshatch/soma-ctrl#readme",
   "engines": {
-    "node": ">=7.0 <10.0"
+    "node": ">=8.16.0 <13.0"
   },
   "dependencies": {
     "debug": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "debug": "^4.0.1",
     "express": "^4.16.3",
     "mqtt": "^2.18.2",
-    "noble": "^1.9.1",
+    "@abandonware/noble": "^1.9.2-1",
     "readline-sync": "^1.4.9",
     "yargs": "^13.2.2"
   },


### PR DESCRIPTION
Closed previous PR because I had a wrong version string in package-lock.json which meant the checksum was wrong, and I couldn't work out how to edit a PR (if that's even possible).

Updated README.md to reflect Node version testing performed.

Tested on Node 8.16.1, 9.11.2, 10.15.2 and 12.11.0, which covers all latest versions current and maintenance releases as of 29/09/2019 and Node 11 for people lagging behind current release.